### PR TITLE
fix: rxjs peer dependency version

### DIFF
--- a/projects/angular-reactive-validation/package.json
+++ b/projects/angular-reactive-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-reactive-validation",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Reactive Forms validation shouldn't require the developer to write lots of HTML to show validation messages. This library makes it easy.",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "@angular/common": "^15.0.0",
     "@angular/core": "^15.0.0",
     "@angular/forms": "^15.0.0",
-    "rxjs": "^6.6.7"
+    "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"


### PR DESCRIPTION
Fixes: #55

Based on version compatibility table found [here](https://github.com/angular/angular/blob/39b707c6028f06f0f52a834c668839c031debc22/aio/content/guide/versions.md).